### PR TITLE
cukes-ldap: allow checking that attribute value is or is not empty

### DIFF
--- a/cukes-ldap/src/main/java/lv/ctco/cukes/ldap/api/ThenSteps.java
+++ b/cukes-ldap/src/main/java/lv/ctco/cukes/ldap/api/ThenSteps.java
@@ -43,12 +43,12 @@ public class ThenSteps {
         entityFacade.entityHasAttributeWithValueOtherThat(attribute, value);
     }
 
-    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with (\\d+) values$")
+    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with (\\d+) values?$")
     public void entityHasAttributeAsArrayOfSize(String attribute, int size) {
         entityFacade.entityHasAttributeAsArrayOfSize(attribute, "=", size);
     }
 
-    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with (>=|>|<=|<|<>) (\\d+) values$")
+    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with (>=|>|<=|<|<>) (\\d+) values?$")
     public void entityHasAttributeAsArrayOfSize(String attribute, String operator, int size) {
         entityFacade.entityHasAttributeAsArrayOfSize(attribute, operator, size);
     }

--- a/cukes-ldap/src/main/java/lv/ctco/cukes/ldap/api/ThenSteps.java
+++ b/cukes-ldap/src/main/java/lv/ctco/cukes/ldap/api/ThenSteps.java
@@ -33,22 +33,22 @@ public class ThenSteps {
         entityFacade.entityDoesNotContainAttribute(attribute);
     }
 
-    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with value \"(.+)\"$")
+    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with value \"(.*)\"$")
     public void entityHasAttributeWithValue(String attribute, String value) {
         entityFacade.entityHasAttributeWithValue(attribute, value);
     }
 
-    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with value other than \"(.+)\"$")
+    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with value other than \"(.*)\"$")
     public void entityHasAttributeWithValueOtherThat(String attribute, String value) {
         entityFacade.entityHasAttributeWithValueOtherThat(attribute, value);
     }
 
-    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with \"(.+)\" values$")
+    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with (\\d+) values$")
     public void entityHasAttributeAsArrayOfSize(String attribute, int size) {
         entityFacade.entityHasAttributeAsArrayOfSize(attribute, "=", size);
     }
 
-    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with (>=|>|<=|<|<>) \"(.+)\" values$")
+    @Then("^entity contains attribute \"([a-zA-Z][a-zA-Z0-9\\-]*)\" with (>=|>|<=|<|<>) (\\d+) values$")
     public void entityHasAttributeAsArrayOfSize(String attribute, String operator, int size) {
         entityFacade.entityHasAttributeAsArrayOfSize(attribute, operator, size);
     }

--- a/cukes-samples/cukes-ldap-sample/src/test/resources/features/LDIF.feature
+++ b/cukes-samples/cukes-ldap-sample/src/test/resources/features/LDIF.feature
@@ -14,7 +14,7 @@ Feature: LDIF showcase
     """
     When the client retrieves entity by DN "cn=John Smith,ou=Users,dc=example,dc=com"
     Then entity contains attribute "sn" with value "Smith"
-    And entity contains attribute "objectclass" with "4" values
+    And entity contains attribute "objectclass" with 4 values
     And entity contains attribute "objectclass" with value "top"
     And entity contains attribute "objectclass" with value "person"
     And entity contains attribute "objectclass" with value "inetOrgPerson"

--- a/cukes-samples/cukes-ldap-sample/src/test/resources/features/ModifyEntity.feature
+++ b/cukes-samples/cukes-ldap-sample/src/test/resources/features/ModifyEntity.feature
@@ -18,7 +18,7 @@ Feature: Modify entity showcase
     When the client updates entity with DN "cn={(cn)},ou=Users,dc=example,dc=com" using prepared modifications
     And the client retrieves entity by DN "cn={(cn)},ou=Users,dc=example,dc=com"
     Then entity exists
-    And entity contains attribute "telephoneNumber" with "1" values
+    And entity contains attribute "telephoneNumber" with 1 values
     And entity contains attribute "telephoneNumber" with value "67890"
 
   Scenario: Should add attributes
@@ -40,7 +40,7 @@ Feature: Modify entity showcase
     When the client updates entity with DN "cn={(cn)},ou=Users,dc=example,dc=com" using prepared modifications
     And the client retrieves entity by DN "cn={(cn)},ou=Users,dc=example,dc=com"
     Then entity exists
-    And entity contains attribute "telephoneNumber" with "2" values
+    And entity contains attribute "telephoneNumber" with 2 values
     And entity contains attribute "telephoneNumber" with value "12345"
     And entity contains attribute "telephoneNumber" with value "67890"
 
@@ -64,5 +64,5 @@ Feature: Modify entity showcase
     When the client updates entity with DN "cn={(cn)},ou=Users,dc=example,dc=com" using prepared modifications
     And the client retrieves entity by DN "cn={(cn)},ou=Users,dc=example,dc=com"
     Then entity exists
-    And entity contains attribute "telephoneNumber" with "1" values
+    And entity contains attribute "telephoneNumber" with 1 values
     And entity contains attribute "telephoneNumber" with value "67890"

--- a/cukes-samples/cukes-ldap-sample/src/test/resources/features/ModifyEntity.feature
+++ b/cukes-samples/cukes-ldap-sample/src/test/resources/features/ModifyEntity.feature
@@ -18,7 +18,7 @@ Feature: Modify entity showcase
     When the client updates entity with DN "cn={(cn)},ou=Users,dc=example,dc=com" using prepared modifications
     And the client retrieves entity by DN "cn={(cn)},ou=Users,dc=example,dc=com"
     Then entity exists
-    And entity contains attribute "telephoneNumber" with 1 values
+    And entity contains attribute "telephoneNumber" with 1 value
     And entity contains attribute "telephoneNumber" with value "67890"
 
   Scenario: Should add attributes
@@ -64,5 +64,5 @@ Feature: Modify entity showcase
     When the client updates entity with DN "cn={(cn)},ou=Users,dc=example,dc=com" using prepared modifications
     And the client retrieves entity by DN "cn={(cn)},ou=Users,dc=example,dc=com"
     Then entity exists
-    And entity contains attribute "telephoneNumber" with 1 values
+    And entity contains attribute "telephoneNumber" with 1 value
     And entity contains attribute "telephoneNumber" with value "67890"


### PR DESCRIPTION
cukes-ldap: allow checking that attribute value is or is not empty

Currently these test steps
`entity contains attribute "someAttr" with value "someExpectedValue"
entity contains attribute "someAttr" with value other than "someExpectedValue"`
does not allow to leave to leave the expected string empty to be able to check that value is or is not empty (there are no step definitions implemented for this purpose).

Also step definition
`And entity contains attribute "someAttribe" with "43" values`
should indicate a digit for better understanding.
