### PR TITLE
correct (more usable) conversion of ldap entry attributes to string

### DIFF
--- a/cukes-ldap/src/test/java/lv/ctco/cukes/ldap/facade/EntityFacadeTest.java
+++ b/cukes-ldap/src/test/java/lv/ctco/cukes/ldap/facade/EntityFacadeTest.java
@@ -1,0 +1,67 @@
+package lv.ctco.cukes.ldap.facade;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import javax.naming.directory.BasicAttributes;
+
+public class EntityFacadeTest {
+    EntityFacade entityFacade;
+
+    @Before
+    public void setUp() throws Exception {
+        entityFacade = new EntityFacade();
+    }
+
+
+    @Test
+    public void byteArrayValueIsCheckedAsString() throws Exception {
+        BasicAttributes entity = new BasicAttributes(true);
+        entity.put("userPassword", new byte[]{50, 82, 115, 48, 67, 99, 54, 74});
+
+        Whitebox.setInternalState(entityFacade, "entity", entity);
+
+        entityFacade.entityHasAttributeWithValue("userpassword", "2Rs0Cc6J");
+    }
+
+    @Test
+    public void charArrayValueIsCheckedAsString() throws Exception {
+        BasicAttributes entity = new BasicAttributes(true);
+        entity.put("userPassword", new char[]{'h', 'e', 'l', 'l', 'o'});
+
+        Whitebox.setInternalState(entityFacade, "entity", entity);
+
+        entityFacade.entityHasAttributeWithValue("userpassword", "hello");
+    }
+
+    @Test
+    public void stringValueIsCheckedAsString() throws Exception {
+        BasicAttributes entity = new BasicAttributes(true);
+        entity.put("userPassword", "hello");
+
+        Whitebox.setInternalState(entityFacade, "entity", entity);
+
+        entityFacade.entityHasAttributeWithValue("userpassword", "hello");
+    }
+
+    @Test
+    public void intArrayValueIsCheckedAsString() throws Exception {
+        BasicAttributes entity = new BasicAttributes(true);
+        entity.put("userPassword", new int[]{1, 2, 3});
+
+        Whitebox.setInternalState(entityFacade, "entity", entity);
+
+        entityFacade.entityHasAttributeWithValue("userpassword", "{1,2,3}");
+    }
+
+    @Test
+    public void intValueIsCheckedAsString() throws Exception {
+        BasicAttributes entity = new BasicAttributes(true);
+        entity.put("userPassword", 3);
+
+        Whitebox.setInternalState(entityFacade, "entity", entity);
+
+        entityFacade.entityHasAttributeWithValue("userpassword", "3");
+    }
+}


### PR DESCRIPTION
Currently method which is used in 
^entity contains attribute "([a-zA-Z][a-zA-Z0-9\-]*)" with value "(.*)"$
step uses simple toString on attribute value
So toString'ed byte[] values look like that - [B@e874448

This fix converts 
* byte[] and char[] array attribute value to String using UTF-8
* other array type values will look like {<el1.toString()>, <el2.toString()>...}
