### PR TITLE
Update GivenSteps.java

### DIFF
--- a/cukes-http/src/main/java/lv/ctco/cukes/http/api/GivenSteps.java
+++ b/cukes-http/src/main/java/lv/ctco/cukes/http/api/GivenSteps.java
@@ -47,7 +47,7 @@ public class GivenSteps {
         this.facade.contentType(contentType);
     }
 
-    @Given("^queryParam \"(.+)\" is \"(.+)\"$")
+    @Given("^queryParam \"(.+)\" is \"(.*)\"$")
     public void query_Param(String key, String value) {
         this.facade.queryParam(key, value);
     }


### PR DESCRIPTION
With the current implementation it is not possible to use dynamic variables in 'queryParam' value.
To be able to use 'queryParam' values from 'Examples'  of 'Scenario Outline' I purpose to use * instead of +