### PR TITLE
-- fixed timestamp step having some incompatible characters 

### DIFF
--- a/cukes-core/src/main/java/lv/ctco/cukes/core/api/GivenSteps.java
+++ b/cukes-core/src/main/java/lv/ctco/cukes/core/api/GivenSteps.java
@@ -44,7 +44,13 @@ public class GivenSteps {
         this.variableFacade.setVariable(varName, value);
     }
 
+    @Deprecated
     @Given("^let variable \"([^\"]*)\" be equal to current timestamp$")
+    public void letVariableBeEqualToCurrentTimestampOld(String varName) {
+        this.variableFacade.setCurrentTimestampToVariable(varName);
+    }
+
+    @Given("^let variable \"([^\"]*)\" be equal to current timestamp$")
     public void letVariableBeEqualToCurrentTimestamp(String varName) {
         this.variableFacade.setCurrentTimestampToVariable(varName);
     }


### PR DESCRIPTION
instead of white-space.
Was revealed upon applying lv.ctco.cukes.core.formatter.CukesJsonFormatter on scenario that had this step definition, and trying to process resulting json with zephyr-sync plugin