### PR TITLE
this commit fixes RestAssuredConfig usage in RestAssuredConfiguration…

### DIFF
--- a/cukes-http/src/main/java/lv/ctco/cukes/http/RestAssuredConfiguration.java
+++ b/cukes-http/src/main/java/lv/ctco/cukes/http/RestAssuredConfiguration.java
@@ -2,15 +2,19 @@ package lv.ctco.cukes.http;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.restassured.config.LogConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.SSLConfig;
 import io.restassured.path.json.config.JsonPathConfig;
 import lv.ctco.cukes.core.CukesOptions;
 import lv.ctco.cukes.core.internal.context.GlobalWorldFacade;
 
+import java.io.PrintStream;
+
 import static io.restassured.config.DecoderConfig.ContentDecoder.DEFLATE;
 import static io.restassured.config.DecoderConfig.decoderConfig;
 import static io.restassured.config.JsonConfig.jsonConfig;
+import static io.restassured.config.LogConfig.logConfig;
 import static io.restassured.config.RedirectConfig.redirectConfig;
 import static io.restassured.config.RestAssuredConfig.newConfig;
 
@@ -21,6 +25,7 @@ public class RestAssuredConfiguration {
     GlobalWorldFacade world;
 
     private RestAssuredConfig restAssuredConfig;
+    private PrintStream logStream;
 
     public RestAssuredConfig getConfig() {
         if (restAssuredConfig == null) {
@@ -30,12 +35,23 @@ public class RestAssuredConfiguration {
     }
 
     private RestAssuredConfig buildRestAssuredConfig() {
-        RestAssuredConfig config = newConfig().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.BIG_DECIMAL))
+        RestAssuredConfig config = newConfig()
+            .jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.BIG_DECIMAL))
             .redirect(redirectConfig().followRedirects(world.getBoolean(CukesOptions.FOLLOW_REDIRECTS, true)));
+        if(logStream != null)
+            config = config.logConfig(logConfig().defaultStream(logStream));
         if (!world.getBoolean(CukesOptions.GZIP_SUPPORT, true)) {
-            config.decoderConfig(decoderConfig().contentDecoders(DEFLATE));
+            config = config.decoderConfig(decoderConfig().contentDecoders(DEFLATE));
         }
-        config.sslConfig(new SSLConfig().allowAllHostnames());
+        config = config.sslConfig(new SSLConfig().allowAllHostnames());
         return config;
+    }
+
+    public void setDefaultStream(PrintStream logStream) {
+        this.logStream = logStream;
+    }
+
+    public void reset() {
+        restAssuredConfig = null;
     }
 }

--- a/cukes-http/src/main/java/lv/ctco/cukes/http/logging/HttpLoggingPlugin.java
+++ b/cukes-http/src/main/java/lv/ctco/cukes/http/logging/HttpLoggingPlugin.java
@@ -11,6 +11,7 @@ import io.restassured.specification.FilterableRequestSpecification;
 import io.restassured.specification.RequestLogSpecification;
 import io.restassured.specification.RequestSpecification;
 import lv.ctco.cukes.core.internal.context.GlobalWorldFacade;
+import lv.ctco.cukes.http.RestAssuredConfiguration;
 import lv.ctco.cukes.http.extension.CukesHttpPlugin;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.event.Level;
@@ -34,17 +35,20 @@ public class HttpLoggingPlugin implements CukesHttpPlugin {
     private static final String DEFAULT_RESPONSE_INCLUDES = "";
 
     private final PrintStream logStream;
+    private RestAssuredConfiguration config;
     private final GlobalWorldFacade world;
 
     @Inject
-    public HttpLoggingPlugin(GlobalWorldFacade world) {
+    public HttpLoggingPlugin(GlobalWorldFacade world, RestAssuredConfiguration config) {
         this.world = world;
+        this.config = config;
         logStream = new LoggerPrintStream(getLogger(world.get(LOGGING_LOGGER_NAME, DEFAULT_LOGGER_NAME)), Level.INFO);
     }
 
     @Override
     public void beforeAllTests() {
-
+        config.setDefaultStream(logStream);
+        config.reset();
     }
 
     @Override
@@ -69,9 +73,6 @@ public class HttpLoggingPlugin implements CukesHttpPlugin {
         }
 
         final FilterableRequestSpecification filterableRequestSpecification = (FilterableRequestSpecification) requestSpecification;
-
-        final RestAssuredConfig config = (filterableRequestSpecification).getConfig();
-        config.logConfig(config.getLogConfig().defaultStream(logStream));
 
         final RequestLogSpecification logSpec = filterableRequestSpecification.log();
         final List<LogDetail> logDetails = parseLogDetails(world.get(LOGGING_REQUEST_INCLUDES, DEFAULT_REQUEST_INCLUDES));

--- a/cukes-http/src/test/java/lv/ctco/cukes/http/logging/HttpLoggingPluginTest.java
+++ b/cukes-http/src/test/java/lv/ctco/cukes/http/logging/HttpLoggingPluginTest.java
@@ -1,0 +1,76 @@
+package lv.ctco.cukes.http.logging;
+
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import lv.ctco.cukes.core.internal.context.GlobalWorldFacade;
+import lv.ctco.cukes.http.RestAssuredConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.internal.util.reflection.Whitebox;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+
+import static lv.ctco.cukes.core.CukesOptions.LOGGING_REQUEST_INCLUDES;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpLoggingPluginTest {
+    private static final String EXPECTED_RESULT =
+        "" +
+            "Request method:\tGET\n" +
+            "Request URI:\thttp://google.com/?q=hi\n" +
+            "Proxy:\t\t\t<none>\n" +
+            "Request params:\tq=hi\n" +
+            "Query params:\t<none>\n" +
+            "Form params:\t<none>\n" +
+            "Path params:\t<none>\n" +
+            "Headers:\t\tAccept=*/*\n" +
+            "Cookies:\t\t<none>\n" +
+            "Multiparts:\t\t<none>\n" +
+            "Body:\t\t\t<none>\n" +
+            "";
+    private ByteArrayOutputStream testOut;
+    private RestAssuredConfiguration config;
+
+    @Mock
+    private GlobalWorldFacade world;
+
+    private HttpLoggingPlugin plugin;
+
+    @Before
+    public void setUp() {
+        testOut = new ByteArrayOutputStream();
+        PrintStream testStream = new PrintStream(testOut);
+
+        config = new RestAssuredConfiguration();
+        Whitebox.setInternalState(config, "world", world);
+
+        plugin = new HttpLoggingPlugin(world, config);
+        Whitebox.setInternalState(plugin, "logStream", testStream);
+        plugin.beforeAllTests();
+    }
+
+    @Test
+    public void testOutputStream() throws UnsupportedEncodingException {
+        when(world.get(LOGGING_REQUEST_INCLUDES, "")).thenReturn("all");
+
+        RequestSpecification specification = RestAssured.given()
+            .config(config.getConfig())
+            .baseUri("http://google.com")
+            .param("q", "hi");
+
+        plugin.beforeRequest(specification);
+
+        specification.get();
+
+        String requestLog = testOut.toString("UTF-8");
+        assertThat(requestLog, is(EXPECTED_RESULT));
+    }
+}


### PR DESCRIPTION
… including logging config made by Logging plugin

RestAssuredConfig is immutable!!!
so any calls like config.logConfig(<something>) does not change logConfig, but rather return new config replacing logConfig with provided