### PR TITLE
Fixing order-dependent test in HttpAssertionFacadeImplTest

### DIFF
--- a/cukes-http/src/test/java/lv/ctco/cukes/http/facade/HttpAssertionFacadeImplTest.java
+++ b/cukes-http/src/test/java/lv/ctco/cukes/http/facade/HttpAssertionFacadeImplTest.java
@@ -140,6 +140,7 @@ public class HttpAssertionFacadeImplTest {
             200,
             "1 expectation failed.\n" +
                 "Expected status code \"200\" but was \"404\" with body <exceeding max size to show>.\n");
+        world.put(ASSERTS_STATUS_CODE_MAX_SIZE, "100");
     }
 
     @Test


### PR DESCRIPTION
Currently, when test shouldNotReturnBodyWhenEnabledButLongerThanMaxSize() runs before shouldReturnBodyWhenEnabledAndNoMax(), this second test fails because the first test sets ASSERTS_STATUS_CODE_MAX_SIZE to be a very low value, 5. The proposed fix is to set ASSERTS_STATUS_CODE_MAX_SIZE to a higher value (currently 100) after shouldNotReturnBodyWhenEnabledButLongerThanMaxSize() finishes.

Please let me know if you want to discuss the changes more.